### PR TITLE
fix for word-break right column

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -77,6 +77,7 @@
       }
       .cv-contact > dd {
         margin-bottom: 1em; 
+        word-break: break-word;
       }
       .cv-languages {
         list-style: none;


### PR DESCRIPTION
After reducing the view-port, the Linkedin link breaks and overflows the right column.

![issue](https://user-images.githubusercontent.com/1714616/78503894-cfcfe080-7769-11ea-815a-14208427f0a0.png)
